### PR TITLE
Fixed styling issue when the displayCalendars is set to '0'

### DIFF
--- a/app/components/reactDatez.js
+++ b/app/components/reactDatez.js
@@ -363,6 +363,7 @@ class ReactDatez extends Component {
 
         const pickerClass = classnames('rdatez-picker', {
             'multi-cal': (this.props.displayCalendars > 1),
+            'no-cal': (this.props.displayCalendars === 0),
             'highlight-weekends': this.props.highlightWeekends,
             'disallow-past': !this.props.allowPast,
             'disallow-future': !this.props.allowFuture,

--- a/app/styles/components/datepickers.css
+++ b/app/styles/components/datepickers.css
@@ -83,6 +83,9 @@ body.date-open {
 			max-width: 400px;
 			min-width: 400px;
 		}
+		&.no-cal{
+			display: none;
+		}
 
 		&.multi-cal {
 			min-width: auto;


### PR DESCRIPTION
Helpful when we want to disable the datepicker from showing calendar.